### PR TITLE
Refactor: modularize the ability to store data on local storage

### DIFF
--- a/frontend/src/components/SideNav.vue
+++ b/frontend/src/components/SideNav.vue
@@ -37,7 +37,7 @@ import {
 @Component
 export default class SideNav extends Vue {
   @Prop(Object)
-  readonly myGoalsData: object | undefined;
+  readonly myGoalsData!: object;
 
   private isOnLocalStorage: boolean = true;
 
@@ -59,14 +59,30 @@ export default class SideNav extends Vue {
       if (clickedSubCat === '비우기') {
         localStorage.clear();
       } else if (clickedSubCat === '저장하기') {
-        localStorage.setItem('mandala_planner', JSON.stringify(this.myGoalsData));
+        this.saveLocalStorage(this.myGoalsData);
       } else if (clickedSubCat === '끄기') {
         this.isOnLocalStorage = false;
+        console.log(this.isOnLocalStorage);
       } else if (clickedSubCat === '사용하기') {
         this.isOnLocalStorage = true;
+        console.log(this.isOnLocalStorage);
       }
     } else if (clickedPriCat === '기능2') {
       console.log('기능2');
+    }
+  }
+
+  saveLocalStorage(data: object): void {
+    localStorage.setItem('mandala_planner', JSON.stringify(data));
+  }
+
+  autoSaveLocalStorage(isOnLocalStorage: boolean, data: object): void {
+    if (isOnLocalStorage === undefined || data === undefined) {
+      if (this.isOnLocalStorage) {
+        this.saveLocalStorage(this.myGoalsData);
+      }
+    } else if (isOnLocalStorage) {
+      this.saveLocalStorage(data);
     }
   }
 }

--- a/frontend/src/views/MandaraView.vue
+++ b/frontend/src/views/MandaraView.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <SideNav :my-goals-data="myGoals" />
+    <SideNav :my-goals-data="myGoals" ref="sideNav" />
     <div class="container min-width-768 pt-5">
       <div class="row justify-content-center" v-for="(row,_,rowIdx) in myGoals" :key="rowIdx">
         <div class="column" v-for="(myGoal,_,colIdx) in row" :key="colIdx">
@@ -232,7 +232,7 @@ export default class MandaraView extends Vue {
     }
 
     this.myGoals[`row${this.clickedRowCol.row}`][`col${this.clickedRowCol.col}`].goal = this.goal;
-    localStorage.setItem('mandala_planner', JSON.stringify(this.myGoals));
+    this.$refs.sideNav.autoSaveLocalStorage();
 
     this.$nextTick(() => {
       this.$refs.modal.hide();


### PR DESCRIPTION
데이터를 로컬 스토리지에 저장하는 기능을 함수로 모듈화

원래는 SideNav에 local storage 관련 작업을 전부 위임하려 하였으나,
created 시점에 데이터를 초기화하는편이 좋은데 created 시점에 SubNav를 통하여 getLocalStorageData를 하는 것은 불가능하여 일부만 위임하였다.
created 시점에 Vue 객체는 부모에서 자식순으로 만들어지므로 MandaraView.vue의 자식인 SideNav.vue는 아직 생성되지 않았기에 함수 호출이 불가능하였다.